### PR TITLE
lint: Fix ineffectual assignment of err

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,8 @@ func main() {
 	switch *enumArg {
 	case EnumFile:
 		requiredFlag(enumFilePath, *enumFilePathVal)
-		file, err := os.Open(*enumFilePathVal)
+		var file *os.File
+		file, err = os.Open(*enumFilePathVal)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
`err` was getting swallowed up inside the case scope, rather than getting bubbled up as intended.