### PR TITLE
Adds a FileEnumeratorWriter that persists all failed blocks to a file

### DIFF
--- a/pump/enum_file_writer.go
+++ b/pump/enum_file_writer.go
@@ -1,0 +1,71 @@
+package pump
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/ipfs/go-cid"
+)
+
+type FailedBlocksWriter interface {
+	Write(c cid.Cid) (int, error)
+	Flush() error
+	Count() uint
+}
+
+var _ FailedBlocksWriter = &FileEnumeratorWriter{}
+var _ FailedBlocksWriter = &NullableFileEnumeratorWriter{}
+
+type FileEnumeratorWriter struct {
+	file  *bufio.Writer
+	count uint
+}
+
+type NullableFileEnumeratorWriter struct {
+	count uint
+}
+
+func NewFileEnumeratorWriter(path string) (enumWriter FailedBlocksWriter, close func() error, err error) {
+	fo, err := os.OpenFile(path, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	w := bufio.NewWriter(fo)
+
+	return &FileEnumeratorWriter{
+		file:  w,
+		count: 0,
+	}, fo.Close, nil
+}
+
+func (f *FileEnumeratorWriter) Write(c cid.Cid) (int, error) {
+	f.count++
+	return f.file.WriteString(fmt.Sprintf("%v\n", c.String()))
+}
+
+func (f *FileEnumeratorWriter) Flush() error {
+	return f.file.Flush()
+}
+
+func (f *FileEnumeratorWriter) Count() uint {
+	return f.count
+}
+
+func NewNullableFileEnumeratorWriter() FailedBlocksWriter {
+	return &NullableFileEnumeratorWriter{}
+}
+
+func (f *NullableFileEnumeratorWriter) Write(c cid.Cid) (int, error) {
+	f.count++
+	return 0, nil
+}
+
+func (f *NullableFileEnumeratorWriter) Flush() error {
+	return nil
+}
+
+func (f *NullableFileEnumeratorWriter) Count() uint {
+	return f.count
+}

--- a/pump/mocks.go
+++ b/pump/mocks.go
@@ -97,11 +97,33 @@ type MockDrain struct {
 	Drained uint32
 }
 
+type MockFailingDrain struct {
+	Drained uint32
+
+	// How many blocks we want the Drain() to simulate as failed
+	BlocksToFail uint
+}
+
 func NewMockDrain() *MockDrain {
 	return &MockDrain{}
 }
 
 func (m *MockDrain) Drain(block Block) error {
 	atomic.AddUint32(&m.Drained, 1)
+	return nil
+}
+
+func NewMockFailingDrain(blocksToFail uint) *MockFailingDrain {
+	return &MockFailingDrain{BlocksToFail: blocksToFail}
+}
+
+func (m *MockFailingDrain) Drain(block Block) error {
+	atomic.AddUint32(&m.Drained, 1)
+
+	if m.BlocksToFail > 0 {
+		m.BlocksToFail--
+		return fmt.Errorf("mocked s3 rate limit error, please slow down")
+	}
+
 	return nil
 }

--- a/pump_test.go
+++ b/pump_test.go
@@ -1,29 +1,83 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/INFURA/ipfs-pump/pump"
 )
 
 func TestPump(t *testing.T) {
-	testPump(t, 50, 1)
-	testPump(t, 50, 50)
-	testPump(t, 50, 100)
-	testPump(t, 500, 10)
+	testPump(t, pump.NewMockDrain(), 50, 0, 1)
+	testPump(t, pump.NewMockDrain(), 50, 0, 50)
+	testPump(t, pump.NewMockDrain(), 50, 0, 100)
+	testPump(t, pump.NewMockDrain(), 500, 0, 10)
+
+	testPump(t, pump.NewMockFailingDrain(5), 10, 5, 1)
+	testPump(t, pump.NewMockFailingDrain(50), 100, 50, 50)
+	testPump(t, pump.NewMockFailingDrain(50), 50, 50, 100)
+	testPump(t, pump.NewMockFailingDrain(500), 5000, 500, 100)
 }
 
-func testPump(t *testing.T, count int, worker uint) {
+func testPump(t *testing.T, drain pump.Drain, count int, failedCount uint, worker uint) {
+	tmpFailedBlocksFile := filepath.Join(os.TempDir(), strconv.Itoa(int(time.Now().Unix()+int64(count)+int64(failedCount)+int64(worker))))
+	defer func() {
+		err := os.Remove(tmpFailedBlocksFile)
+		require.NoError(t, err)
+	}()
+
+	t.Logf("Logging failed blocks in Enumerator format to file: %v", tmpFailedBlocksFile)
+
 	blocks := sync.Map{}
 
 	enum := pump.NewMockEnumerator(&blocks, count)
 	coll := pump.NewMockCollector(&blocks)
-	drain := pump.NewMockDrain()
 
-	PumpIt(enum, coll, drain, worker)
+	failedBlocksWriter, closeWriter, err := pump.NewFileEnumeratorWriter(tmpFailedBlocksFile)
+	require.NoError(t, err)
 
-	assert.Equal(t, uint32(count), drain.Drained)
+	PumpIt(enum, coll, drain, worker, failedBlocksWriter)
+
+	mockDrain, ok := drain.(*pump.MockDrain)
+	if ok {
+		assert.Equal(t, uint32(count), mockDrain.Drained)
+	}
+
+	mockFailedDrain, ok := drain.(*pump.MockFailingDrain)
+	if ok {
+		assert.Equal(t, uint32(count), mockFailedDrain.Drained)
+		assert.Equal(t, uint(0), mockFailedDrain.BlocksToFail)
+		assert.Equal(t, failedCount, failedBlocksWriter.Count())
+	}
+
+	err = closeWriter()
+	require.NoError(t, err)
+
+	// Test the file enumerator was generated correctly and can be re-used to pump all the failed blocks again
+	if failedCount > 0 {
+		var emumFile *os.File
+		emumFile, err = os.Open(tmpFailedBlocksFile)
+		require.NoError(t, err)
+
+		// Use a real file enumerator this time, not a mock
+		enum, err := pump.NewFileEnumerator(emumFile)
+		require.NoError(t, err)
+
+		// But swipe the failing mocked drain with a successful one
+		drain = pump.NewMockDrain()
+		PumpIt(enum, coll, drain, worker, pump.NewNullableFileEnumeratorWriter())
+
+		mockDrain, ok := drain.(*pump.MockDrain)
+		if ok {
+			// Assert all the previously collected failed blocks were successfully pushed now
+			assert.Equal(t, uint32(failedCount), mockDrain.Drained)
+		}
+	}
 }


### PR DESCRIPTION
The resulted file is enumerator compatible so we can use it to re-pump all the failed blocks to the drainer.

Can be enabled with: `--failed-blocks-path /home/ec2-user/ipfs_blocks_dev_failed_cids.txt`